### PR TITLE
Set accept header in function ListUserRepos

### DIFF
--- a/github/apps_installation.go
+++ b/github/apps_installation.go
@@ -67,6 +67,9 @@ func (s *AppsService) ListUserRepos(ctx context.Context, id int, opt *ListOption
 		return nil, nil, err
 	}
 
+	// TODO: remove custom Accept header when this API fully launches.
+	req.Header.Set("Accept", mediaTypeIntegrationPreview)
+
 	var r struct {
 		Repositories []*Repository `json:"repositories"`
 	}


### PR DESCRIPTION
Or GitHub may return:
`Message: "If you would like to help us test the Integrations API during its preview period, you must specify a custom media type in the 'Accept' header. Please see the docs for full details.",`